### PR TITLE
Tidying for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ registry.
 
 ## Basic Usage
 ```rust
-use crate_index::{Index, Url, Metadata, Version};
+use crate_index::{Index, Url, Record, Version};
 
 // Create a new index, backed by the filesystem and a git repository
 let root = "/index";
@@ -22,15 +22,15 @@ let mut index = Index::initialise(root, download)
     .build()
     .await?;
 
-// Create a new crate 'Metadata' object
+// Create a new crate 'Record' object
 let name = "foo";
 let version = Version::parse("0.1.0").unwrap();
 let check_sum = "d867001db0e2b6e0496f9fac96930e2d42233ecd3ca0413e0753d4c7695d289c";
 
-let metadata = Metadata::new(name, version, check_sum);
+let record = Record::new(name, version, check_sum);
 
-// Insert the Metadata into the index
-index.insert(metadata).await?;
+// Insert the Record into the index
+index.insert(record).await?;
 
 ```
 

--- a/src/blocking/index/tree.rs
+++ b/src/blocking/index/tree.rs
@@ -1,6 +1,6 @@
 use crate::{
     index::{Tree as AsyncTree, TreeBuilder as AsyncTreeBuilder},
-    Metadata, Result,
+    Record, Result,
 };
 use semver::Version;
 use std::{
@@ -134,7 +134,7 @@ impl Tree {
     ///
     /// This method can fail if the metadata is deemed to be invalid, or if the
     /// filesystem cannot be written to.
-    pub fn insert(&mut self, crate_metadata: Metadata) -> Result<()> {
+    pub fn insert(&mut self, crate_metadata: Record) -> Result<()> {
         block_on(self.async_tree.insert(crate_metadata))
     }
 
@@ -190,7 +190,7 @@ impl Tree {
 #[cfg(test)]
 mod tests {
 
-    use super::{Metadata, Tree};
+    use super::{Record, Tree};
     use crate::{Error, Url};
     use semver::Version;
     use std::path::PathBuf;
@@ -254,8 +254,8 @@ mod tests {
         tree.insert(new_metadata).expect("invalid");
     }
 
-    fn metadata(name: &str, version: &str) -> Metadata {
-        Metadata::new(name, Version::parse(version).unwrap(), "checksum")
+    fn metadata(name: &str, version: &str) -> Record {
+        Record::new(name, Version::parse(version).unwrap(), "checksum")
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@
 //! In normal usage, it would not be required to use these underlying types.
 //! They are exposed here so that can be reused in other crates.
 
-use crate::{Metadata, Result, Url};
+use crate::{Record, Result, Url};
 use async_std::path::PathBuf;
 
 mod file;
@@ -199,7 +199,7 @@ impl Index {
     ///
     /// This method can fail if the metadata is deemed to be invalid, or if the
     /// filesystem cannot be written to.
-    pub async fn insert(&mut self, crate_metadata: Metadata) -> Result<()> {
+    pub async fn insert(&mut self, crate_metadata: Record) -> Result<()> {
         let commit_message = format!(
             "updating crate `{}#{}`",
             crate_metadata.name(),
@@ -246,7 +246,7 @@ impl Index {
 #[cfg(test)]
 mod tests {
     use super::Index;
-    use crate::{index::Metadata, Url};
+    use crate::{index::Record, Url};
     use async_std::path::PathBuf;
     use semver::Version;
     use test_case::test_case;
@@ -319,7 +319,7 @@ mod tests {
         });
     }
 
-    fn metadata(name: &str, version: &str) -> Metadata {
-        Metadata::new(name, Version::parse(version).unwrap(), "checksum")
+    fn metadata(name: &str, version: &str) -> Record {
+        Record::new(name, Version::parse(version).unwrap(), "checksum")
     }
 }

--- a/src/index/file.rs
+++ b/src/index/file.rs
@@ -294,29 +294,17 @@ mod tests {
 
         // create index file and seed with initial metadata
         index_file
-            .insert(Record::new(
-                "some-name",
-                Version::new(0, 1, 0),
-                "checksum",
-            ))
+            .insert(Record::new("some-name", Version::new(0, 1, 0), "checksum"))
             .await
             .unwrap();
 
         index_file
-            .insert(Record::new(
-                "some-name",
-                Version::new(0, 1, 1),
-                "checksum",
-            ))
+            .insert(Record::new("some-name", Version::new(0, 1, 1), "checksum"))
             .await
             .unwrap();
 
         index_file
-            .insert(Record::new(
-                "some-name",
-                Version::new(0, 2, 0),
-                "checksum",
-            ))
+            .insert(Record::new("some-name", Version::new(0, 2, 0), "checksum"))
             .await
             .unwrap();
 

--- a/src/index/tree.rs
+++ b/src/index/tree.rs
@@ -1,6 +1,6 @@
 use super::Config;
 use crate::{
-    index::{IndexFile, Metadata},
+    index::{IndexFile, Record},
     utils,
     validate::Error as ValidationError,
     Error, Result,
@@ -158,7 +158,7 @@ impl Tree {
     ///
     /// This method can fail if the metadata is deemed to be invalid, or if the
     /// filesystem cannot be written to.
-    pub async fn insert(&mut self, crate_metadata: Metadata) -> Result<()> {
+    pub async fn insert(&mut self, crate_metadata: Record) -> Result<()> {
         self.validate_name(crate_metadata.name())?;
 
         let crate_name = crate_metadata.name().clone();
@@ -261,7 +261,7 @@ fn canonicalise(name: impl AsRef<str>) -> String {
 #[cfg(test)]
 mod tests {
 
-    use super::{Metadata, Tree};
+    use super::{Record, Tree};
     use crate::{Error, Url};
     use async_std::path::PathBuf;
     use semver::Version;
@@ -330,8 +330,8 @@ mod tests {
         });
     }
 
-    fn metadata(name: &str, version: &str) -> Metadata {
-        Metadata::new(name, Version::parse(version).unwrap(), "checksum")
+    fn metadata(name: &str, version: &str) -> Record {
+        Record::new(name, Version::parse(version).unwrap(), "checksum")
     }
 
     #[async_std::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ mod error;
 pub use error::{Error, Result};
 
 mod metadata;
-pub use metadata::Metadata;
+
+pub use metadata::{Dependency, DependencyKind, Metadata};
 
 pub mod index;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! # Basic Usage
 //! ```no_run
-//! use crate_index::{Index, Url, Metadata, Version};
+//! use crate_index::{Index, Url, Record, Version};
 //! # use crate_index::Error;
 //!
 //! # async {
@@ -20,15 +20,15 @@
 //!     .build()
 //!     .await?;
 //!
-//! // Create a new crate 'Metadata' object
+//! // Create a new crate 'Record' object
 //! let name = "foo";
 //! let version = Version::parse("0.1.0").unwrap();
 //! let check_sum = "d867001db0e2b6e0496f9fac96930e2d42233ecd3ca0413e0753d4c7695d289c";
 //!
-//! let metadata = Metadata::new(name, version, check_sum);
+//! let record = Record::new(name, version, check_sum);
 //!
-//! // Insert the Metadata into the index
-//! index.insert(metadata).await?;
+//! // Insert the Record into the index
+//! index.insert(record).await?;
 //!
 //! # Ok::<(), Error>(())
 //! # };
@@ -41,9 +41,9 @@
 mod error;
 pub use error::{Error, Result};
 
-mod metadata;
+mod record;
 
-pub use metadata::{Dependency, DependencyKind, Metadata};
+pub use record::{Dependency, DependencyKind, Record};
 
 pub mod index;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -112,6 +112,7 @@ impl fmt::Display for Metadata {
     }
 }
 
+/// A dependency on another crate
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Dependency {
     /// Name of the dependency.
@@ -156,9 +157,10 @@ pub struct Dependency {
     package: Option<String>,
 }
 
+/// Type of crate dependency
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-enum DependencyKind {
+pub enum DependencyKind {
     /// A dependency used only during testing
     Dev,
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,7 +7,7 @@ use url::Url;
 ///
 /// *[See the documentation for details](https://doc.rust-lang.org/cargo/reference/registries.html)*
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Metadata {
+pub struct Record {
     name: String,
 
     vers: Version,
@@ -26,7 +26,7 @@ pub struct Metadata {
     links: Option<String>,
 }
 
-impl Metadata {
+impl Record {
     /// Create a new metadata object.
     ///
     /// The method parameters are all required, optional parameters can be set
@@ -106,7 +106,7 @@ impl Metadata {
     }
 }
 
-impl fmt::Display for Metadata {
+impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &serde_json::to_string(self).unwrap())
     }
@@ -173,7 +173,7 @@ pub enum DependencyKind {
 
 #[cfg(test)]
 mod tests {
-    use super::Metadata;
+    use super::Record;
     use semver::Version;
 
     #[test]
@@ -182,7 +182,7 @@ mod tests {
         let version = Version::parse("0.1.0").unwrap();
         let check_sum = "d867001db0e2b6e0496f9fac96930e2d42233ecd3ca0413e0753d4c7695d289c";
 
-        let metadata = Metadata::new(name, version, check_sum);
+        let metadata = Record::new(name, version, check_sum);
 
         let expected = r#"{"name":"foo","vers":"0.1.0","cksum":"d867001db0e2b6e0496f9fac96930e2d42233ecd3ca0413e0753d4c7695d289c","yanked":false}"#.to_string();
         let actual = metadata.to_string();
@@ -218,7 +218,7 @@ mod tests {
         }
         "#;
 
-        let _: Metadata = serde_json::from_str(example1).unwrap();
+        let _: Record = serde_json::from_str(example1).unwrap();
 
         let example2 = r#"
         {
@@ -252,7 +252,7 @@ mod tests {
         }
         "#;
 
-        let _: Metadata = serde_json::from_str(example2).unwrap();
+        let _: Record = serde_json::from_str(example2).unwrap();
     }
 
     #[test]
@@ -261,7 +261,7 @@ mod tests {
         let version = Version::parse("0.1.0").unwrap();
         let check_sum = "CHECK_SUM";
 
-        let mut metadata = Metadata::new(name, version, check_sum);
+        let mut metadata = Record::new(name, version, check_sum);
 
         assert!(!metadata.yanked());
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,7 +6,7 @@ use url::Url;
 /// Rust crate metadata, as stored in the crate index.
 ///
 /// *[See the documentation for details](https://doc.rust-lang.org/cargo/reference/registries.html)*
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Record {
     name: String,
 
@@ -106,6 +106,12 @@ impl Record {
     }
 }
 
+impl PartialOrd for Record {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.version().partial_cmp(other.version())
+    }
+}
+
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &serde_json::to_string(self).unwrap())
@@ -113,7 +119,7 @@ impl fmt::Display for Record {
 }
 
 /// A dependency on another crate
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Dependency {
     /// Name of the dependency.
     /// If the dependency is renamed from the original package name,
@@ -158,7 +164,7 @@ pub struct Dependency {
 }
 
 /// Type of crate dependency
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DependencyKind {
     /// A dependency used only during testing

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,7 +6,7 @@ use url::Url;
 /// Rust crate metadata, as stored in the crate index.
 ///
 /// *[See the documentation for details](https://doc.rust-lang.org/cargo/reference/registries.html)*
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Record {
     name: String,
 
@@ -113,7 +113,7 @@ impl fmt::Display for Record {
 }
 
 /// A dependency on another crate
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dependency {
     /// Name of the dependency.
     /// If the dependency is renamed from the original package name,
@@ -158,7 +158,7 @@ pub struct Dependency {
 }
 
 /// Type of crate dependency
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DependencyKind {
     /// A dependency used only during testing


### PR DESCRIPTION
- rename `Metadata` -> `Record`
- expose `Dependency` and `DependencyKind` objects in public API